### PR TITLE
Add badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Alternating Case [![Build Status](https://travis-ci.org/haykam821/Alternating-Case.svg?branch=master)](https://travis-ci.org/haykam821/Alternating-Case)
+# Alternating Case
+
+[![Travis (.org)](https://img.shields.io/travis/haykam821/Alternating-Case.svg?style=popout)](https://travis-ci.org/haykam821/Alternating-Case)
 
 This is a simple Node.js package that allows you to create strings that alternate in case.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Alternating Case
 
+[![GitHub release](https://img.shields.io/github/release/haykam821/Alternating-Case.svg?style=popout&label=github)](https://github.com/haykam821/Alternating-Case/releases/latest)
+[![npm](https://img.shields.io/npm/v/alternating-case.svg?style=popout&colorB=red)](https://www.npmjs.com/package/alternating-case)
 [![Travis (.org)](https://img.shields.io/travis/haykam821/Alternating-Case.svg?style=popout)](https://travis-ci.org/haykam821/Alternating-Case)
 
 This is a simple Node.js package that allows you to create strings that alternate in case.


### PR DESCRIPTION
Currently the README only has a single badge for Travis CI's builds. This pull request adds 2 other badges from [shields.io](https://shields.io/) for releases on npm and GitHub, and changes the build badge to use that service as well.